### PR TITLE
Add capitalize option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Codenameize Version History
 
+## next
+
+- Add the `capitalize` in the parseoptions function so that it flows through
+
 ## 1.0.1 (25 Oct 2018)
 
 - JSON.stringify objects (and arrays) when used as seed values.

--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ function parseOptions(options) {
 	response.hashAlgorithm = options && isString(options.hashAlgorithm) ? options.hashAlgorithm : 'md5';
 	response.separator = options && isString(options.separator) ? options.separator : '-';
 
+	if (options && options.capitalize === true) {
+		response.capitalize = options.capitalize;
+	}
+	
 	return response;
 }
 


### PR DESCRIPTION
`Capitalize` didn't make it's way through the parseOptions function to be used in the codenamize function